### PR TITLE
Pin it to the version within buildspace to resolve unwrap error

### DIFF
--- a/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
+++ b/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
@@ -56,7 +56,7 @@
       },
       "outputs": [],
       "source": [
-        "!wget -q https://github.com/ShivamShrirao/diffusers/raw/main/examples/dreambooth/train_dreambooth.py\n",
+        "!wget -q https://raw.githubusercontent.com/buildspace/diffusers/main/examples/dreambooth/train_dreambooth.py\n",
         "!wget -q https://github.com/ShivamShrirao/diffusers/raw/main/scripts/convert_diffusers_to_original_stable_diffusion.py\n",
         "%pip install -qq git+https://github.com/ShivamShrirao/diffusers\n",
         "%pip install -q -U --pre triton\n",


### PR DESCRIPTION
to fix this error:

Steps: 100% 800/800 [10:59<00:00,  1.22it/s, loss=0.189, lr=1e-6]Traceback (most recent call last):
  File "train_dreambooth.py", line 822, in <module>
    main(args)
  File "train_dreambooth.py", line 815, in main
    save_weights(global_step)
  File "train_dreambooth.py", line 682, in save_weights
    text_enc_model = accelerator.unwrap_model(text_encoder, keep_fp32_wrapper=True)
TypeError: unwrap_model() got an unexpected keyword argument 'keep_fp32_wrapper' Steps: 100% 800/800 [10:59<00:00,  1.21it/s, loss=0.189, lr=1e-6] Traceback (most recent call last):
  File "/usr/local/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/accelerate/commands/accelerate_cli.py", line 43, in main
    args.func(args)
  File "/usr/local/lib/python3.8/dist-packages/accelerate/commands/launch.py", line 837, in launch_command
    simple_launcher(args)
  File "/usr/local/lib/python3.8/dist-packages/accelerate/commands/launch.py", line 354, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python3', 'train_dreambooth.py', '--pretrained_model_name_or_path=runwayml/stable-diffusion-v1-5', '--pretrained_vae_name_or_path=stabilityai/sd-vae-ft-mse', '--output_dir=/content/drive/MyDrive/stable_diffusion_weights/test', '--revision=fp16', '--with_prior_preservation', '--prior_loss_weight=1.0', '--seed=1337', '--resolution=500', '--train_batch_size=1', '--train_text_encoder', '--mixed_precision=fp16', '--use_8bit_adam', '--gradient_accumulation_steps=1', '--learning_rate=1e-6', '--lr_scheduler=constant', '--lr_warmup_steps=0', '--num_class_images=50', '--sample_batch_size=4', '--max_train_steps=800', '--save_interval=10000', '--save_sample_prompt=photo of daragha man', '--concepts_list=concepts_list.json']' returned non-zero exit status 1.