### PR TITLE
update the accelerate pip package

### DIFF
--- a/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
+++ b/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
@@ -60,7 +60,7 @@
         "!wget -q https://github.com/ShivamShrirao/diffusers/raw/main/scripts/convert_diffusers_to_original_stable_diffusion.py\n",
         "%pip install -qq git+https://github.com/ShivamShrirao/diffusers\n",
         "%pip install -q -U --pre triton\n",
-        "%pip install -q accelerate==0.12.0 transformers ftfy bitsandbytes gradio natsort"
+        "%pip install -q accelerate==0.15.0 transformers ftfy bitsandbytes gradio natsort"
       ]
     },
     {


### PR DESCRIPTION
train_dreambooth.py expects [`unwrap_model()`](https://huggingface.co/docs/accelerate/v0.15.0/en/package_reference/accelerator#accelerate.Accelerator.unwrap_model) to accept the `keep_fp32_wrapper` parameter. Updating accelerate from `0.12.0` -->  `0.15.0` should fix it